### PR TITLE
Display target database name when execute perform_drop_databases

### DIFF
--- a/lib/server_settings/tasks/db.rake
+++ b/lib/server_settings/tasks/db.rake
@@ -14,6 +14,16 @@ namespace :server_settings do
         end
       end
 
+      def show_all_databases(all_db_configs)
+        if all_db_configs.blank?
+          puts "There is no databases."
+        else
+          all_db_configs.each do |config, _|
+            puts format("* %-15s: exists database '%s'", config["host"], config["database"]).colorize(:green)
+          end
+        end
+      end
+
       def show_new_databases(new_db_configs)
         if new_db_configs.blank?
           puts "There is no new databases."
@@ -84,6 +94,7 @@ namespace :server_settings do
     end
 
     def perform_drop_databases(all_db_configs)
+      show_all_databases(all_db_configs)
       confirm_and_execute "Are you sure you want to execute above?" do
         all_db_configs.each do |config, client|
           command = "DROP DATABASE IF EXISTS #{ config['database'] }"

--- a/lib/server_settings/tasks/db.rake
+++ b/lib/server_settings/tasks/db.rake
@@ -16,7 +16,7 @@ namespace :server_settings do
 
       def show_all_databases(all_db_configs)
         if all_db_configs.blank?
-          puts "There is no databases."
+          puts "There are no databases."
         else
           all_db_configs.each do |config, _|
             puts format("* %-15s: exists database '%s'", config["host"], config["database"]).colorize(:green)
@@ -26,7 +26,7 @@ namespace :server_settings do
 
       def show_new_databases(new_db_configs)
         if new_db_configs.blank?
-          puts "There is no new databases."
+          puts "There are no new databases."
         else
           new_db_configs.each do |config, _|
             puts format("* %-15s: new database '%s'", config["host"], config["database"]).colorize(:green)


### PR DESCRIPTION
When execute `db:create:execute` task, it displays target database.
But when execute `db:drop` task, it does not.
I fixed it to display target database name.

(`db:database:drop` task is my custom task which calls `perform_drop_databases` inside.)

before
```
-> % RAILS_ENV=development bundle exec rails db:database:drop
Are you sure you want to execute above? (yes/N): n
Operation canceled.
```

after
```
-> % RAILS_ENV=development bundle exec rails db:database:drop
* 127.0.0.1      : exists database 'hoge'
Are you sure you want to execute above? (yes/N): n
Operation canceled.
```