### PR TITLE
support Structured hosts

### DIFF
--- a/example/sample.rb
+++ b/example/sample.rb
@@ -30,6 +30,16 @@ database:
   user:
     :database: dbname-user
     :host: 192.168.100.3
+
+memcached:
+  port: 11211
+  hosts:
+    -
+      name: test-1
+      host: 127.0.0.1
+    -
+      name: test-2
+      host: 192.168.0.2
 EOF
 
 # Load Configuration
@@ -51,3 +61,5 @@ end
 
 # Database Configuration
 p ServerSettings.database.hosts
+
+p ServerSettings.memcached.hosts

--- a/lib/server_settings/host.rb
+++ b/lib/server_settings/host.rb
@@ -1,16 +1,37 @@
 class ServerSettings
-
   class Host
-    attr_accessor :host, :port
-    def initialize(host,port)
+    attr_accessor :host, :port, :opt
+
+    def initialize(host, port, opt = {})
       @host = host
       @port = port
+
+      @host = opt.delete("host") if opt.key?("host")
+      @port = opt.delete("port") if opt.key?("port")
+      @opt = opt
     end
 
-    def self.parse(host_line)
-      host, port = host_line.split(/:/)
-      self.new(host,port)
+    def to_h
+      basic = Hash.new
+      basic["host"] = host if host
+      basic["port"] = port if port
+      if opt
+        opt.merge(basic)
+      else
+        basic
+      end
+    end
+
+    class << self
+      def parse(host_line)
+        case host_line
+        when String
+          host, port = host_line.split(/:/)
+          new(host, port)
+        when Hash
+          new(nil, nil, host_line)
+        end
+      end
     end
   end
-
 end

--- a/lib/server_settings/host_collection.rb
+++ b/lib/server_settings/host_collection.rb
@@ -14,14 +14,19 @@ class ServerSettings
     end
 
     def with_format(format)
-      self.map do |host|
-        replacemap = @properties
-        replacemap['%host'] = host.host
-        replacemap['%port'] = host.port if host.port
+      self.map do |h|
+        host = @properties.merge(h.to_h)
+        replacemap = @properties.inject({}) { |a, (k, v)| a["%#{k}"] = v.to_s; a }
+        replacemap['%host'] = host["host"]
+        replacemap['%port'] = host["port"].to_s if host["port"]
         replacemap.inject(format) do |string, mapping|
           string.gsub(*mapping)
         end
       end
+    end
+
+    def with_hash
+      map { |host| @properties.merge(host.to_h) }
     end
 
     # Errors

--- a/lib/server_settings/role.rb
+++ b/lib/server_settings/role.rb
@@ -9,12 +9,10 @@ class ServerSettings
     end
 
     def load(config)
-      role_options = config.keys.select{|s| s != "hosts"}
-      @settings = Hash[*role_options.map do |option_name|
-                         [ "%#{option_name}", config[option_name].to_s]
-                       end.flatten]
-      if config.has_key?("hosts")
-        config["hosts"]= HostCollection.new(config["hosts"], @settings)
+      if config.key?("hosts")
+        hosts = config.delete("hosts")
+        prop = config.dup
+        config["hosts"]= HostCollection.new(hosts, prop)
       end
       config
     end

--- a/spec/lib/servers_config_spec.rb
+++ b/spec/lib/servers_config_spec.rb
@@ -297,4 +297,85 @@ EOS
       end
     end
   end
+
+  describe "structured hosts" do
+    describe "ServerSettings::HostCollection#with_hash" do
+      context "with default port" do
+        let(:structured_hosts_config) { <<EOS }
+memcached:
+  port: 11211
+  hosts:
+    -
+      name: test-1
+      host: 127.0.0.1
+    -
+      name: test-2
+      host: 192.168.0.2
+EOS
+
+        before do
+          ServerSettings.load_from_yaml(structured_hosts_config)
+        end
+
+        it "returns array with hash" do
+          expect(ServerSettings.memcached.hosts.with_hash).to include(
+            {"name" => "test-1", "host" => "127.0.0.1", "port" => 11211},
+            {"name" => "test-2", "host" => "192.168.0.2", "port" => 11211}
+          )
+        end
+      end
+
+      context "with default host and port" do
+        let(:structured_hosts_config) { <<EOS }
+memcached:
+  port: 11211
+  host: 127.0.0.1
+  hosts:
+    -
+      name: test-1
+    -
+      name: test-2
+      host: 192.168.0.2
+EOS
+
+        before do
+          ServerSettings.load_from_yaml(structured_hosts_config)
+        end
+
+        it "returns array with hash" do
+          expect(ServerSettings.memcached.hosts.with_hash).to include(
+            {"name" => "test-1", "host" => "127.0.0.1", "port" => 11211},
+            {"name" => "test-2", "host" => "192.168.0.2", "port" => 11211}
+          )
+        end
+      end
+    end
+
+    describe "ServerSettings::HostCollection#with_format" do
+      context "with default host and port" do
+        let(:structured_hosts_config) { <<EOS }
+memcached:
+  port: 11211
+  host: 127.0.0.1
+  hosts:
+    -
+      name: test-1
+    -
+      name: test-2
+      host: 192.168.0.2
+EOS
+
+        before do
+          ServerSettings.load_from_yaml(structured_hosts_config)
+        end
+
+        it "returns Array with string" do
+          expect(ServerSettings.memcached.hosts.with_format("%host:%port")).to include(
+            "127.0.0.1:11211",
+            "192.168.0.2:11211"
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
`hosts` にURIでは表現しきれないものを定義したい場合に構造体を使えるようにしました。

例・使い方については `example/sample.rb` をご覧ください。