### PR TITLE
randomize host order

### DIFF
--- a/lib/server_settings/capistrano.rb
+++ b/lib/server_settings/capistrano.rb
@@ -15,7 +15,7 @@ module Capistrano
                 role_properties[:active]     = true if hosts.properties["%active"]
                 role role.to_sym, *hosts.map(&:host), role_properties
               else
-                role role.to_sym, *hosts.map(&:host)
+                role role.to_sym, *hosts.map(&:host).shuffle
               end
             end
           end


### PR DESCRIPTION
hostの登録順をランダムに入れ替えます。
以下の状況下で一部のネットワークにトラフィック負荷を改善することが目的です。

- 大量のサーバが1つのロールに入っている
- yamlへの登録順序が物理環境とマッチしていて偏っている
- max_hosts指定で同時実行ホスト数を制限しても偏りがある