### PR TITLE
Support Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Exec Rspec
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - 3.0
+          - 3.1
+          - 3.2
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '${{ matrix.ruby_version }}'
+          bundler: latest
+          bundler-cache: true
+      - name: Run sample
+        run: bundle exec ruby example/sample.rb
+      - name: Run RSpec
+        run: RUBYOPT='-W:deprecated' bundle exec rspec spec

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.ruby-version

--- a/lib/server_settings.rb
+++ b/lib/server_settings.rb
@@ -56,7 +56,7 @@ class ServerSettings
     end
 
     def load_from_yaml(yaml)
-      config = YAML.load(yaml)
+      config = YAML.safe_load(yaml, permitted_classes: [Symbol], aliases: true)
       config.each do |role, config|
         instance << role_klass(config).new(role, config)
       end


### PR DESCRIPTION
`YAML.load` を互換な方法に書き換える
ついでに、GitHub Actions のテストを追加